### PR TITLE
Force install of bioperl modules regardless of build test failures.

### DIFF
--- a/components/insaflu-server/install.sh
+++ b/components/insaflu-server/install.sh
@@ -73,7 +73,7 @@ echo "Install bioperl"
 mkdir -p /root/.cpan/CPAN && mv /tmp_install/configs/CPAN/MyConfig.pm /root/.cpan/CPAN/MyConfig.pm
 export PERL_MM_USE_DEFAULT=1
 export PERL_EXTUTILS_AUTOINSTALL="--defaultdeps"
-cpan CJFIELDS/BioPerl-1.6.924.tar.gz
+cpan -f -i CJFIELDS/BioPerl-1.6.924.tar.gz
 if [ $? -ne 0 ]; then
     echo "Error installing Bioperl"
     exit 1


### PR DESCRIPTION
Use `cpan -f -i` to force installation of modules regardless of build test failures.

Fix #13 